### PR TITLE
Fix prompt name collisions

### DIFF
--- a/Services/PromptService.cs
+++ b/Services/PromptService.cs
@@ -107,6 +107,18 @@ dados e muito mais!'";
                 throw new InvalidOperationException($"Prompt com ID {id} não encontrado");
             }
 
+            // Verifica se o novo nome já está sendo utilizado por outro prompt
+            if (!string.Equals(prompt.Name, request.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                var duplicate = await _context.Prompts
+                    .AnyAsync(p => p.Name == request.Name && p.Id != id);
+
+                if (duplicate)
+                {
+                    throw new InvalidOperationException($"Já existe um prompt com o nome '{request.Name}'");
+                }
+            }
+
             prompt.Name = request.Name;
             prompt.Content = request.Content;
             prompt.IsActive = request.IsActive;


### PR DESCRIPTION
## Summary
- ensure duplicate prompt names can't be used on update

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405a7099408329a7d86feadc27ee1a