### PR TITLE
Fix typo in Azure OpenAI exception

### DIFF
--- a/Controllers/EmailController.cs
+++ b/Controllers/EmailController.cs
@@ -2,7 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using AzureChatGptMiddleware.Models; // Assegura que ErrorResponseModel está acessível
 using AzureChatGptMiddleware.Services;
-using AzureChatGptMiddleware.Exceptions; // Para AzureOpenAIComunicationException
+using AzureChatGptMiddleware.Exceptions; // Para AzureOpenAICommunicationException
 using Microsoft.AspNetCore.Http; // Necessário para StatusCodes
 
 namespace AzureChatGptMiddleware.Controllers
@@ -40,7 +40,7 @@ namespace AzureChatGptMiddleware.Controllers
         /// <response code="400">Requisição inválida. Ocorre se o conteúdo do e-mail não atender aos critérios de validação (ex: ausente, tamanho excedido - via FluentValidation).</response>
         /// <response code="401">Não autorizado. Ocorre se o token JWT ou a API Key forem inválidos ou ausentes.</response>
         /// <response code="500">Erro interno do servidor. Pode ocorrer devido a falhas na comunicação com o Azure OpenAI Service, problemas no serviço de log, ou outras exceções inesperadas.</response>
-        /// <response code="503">Serviço indisponível. Pode ser retornado especificamente se o Azure OpenAI Service estiver inacessível ou retornar um erro indicando indisponibilidade (requer tratamento da AzureOpenAIComunicationException).</response>
+        /// <response code="503">Serviço indisponível. Pode ser retornado especificamente se o Azure OpenAI Service estiver inacessível ou retornar um erro indicando indisponibilidade (requer tratamento da AzureOpenAICommunicationException).</response>
         [HttpPost("process")]
         [ProducesResponseType(typeof(EmailResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(ErrorResponseModel), StatusCodes.Status400BadRequest)] // Também pode ser ValidationProblemDetails
@@ -86,10 +86,10 @@ namespace AzureChatGptMiddleware.Controllers
                     return StatusCode(StatusCodes.Status500InternalServerError, new ErrorResponseModel { Message = "E-mail processado, mas falha ao registrar o log da requisição." });
                 }
             }
-            catch (AzureOpenAIComunicationException openAIEx)
+            catch (AzureOpenAICommunicationException openAIEx)
             {
                 _logger.LogError(openAIEx, "Erro de comunicação com Azure OpenAI Service ao processar e-mail. ClientInfo: {ClientInfo}. Status Code: {StatusCode}. ErrorContent: {ErrorContent}", clientInfo, openAIEx.StatusCode, openAIEx.ErrorResponseContent);
-                await TryLogErrorToDatabase(request.Message, $"AzureOpenAIComunicationException: {openAIEx.Message} (StatusCode: {openAIEx.StatusCode})", clientInfo);
+                await TryLogErrorToDatabase(request.Message, $"AzureOpenAICommunicationException: {openAIEx.Message} (StatusCode: {openAIEx.StatusCode})", clientInfo);
 
                 // Retorna 503 se for um erro de comunicação/serviço claro, senão 500.
                 if (openAIEx.StatusCode == System.Net.HttpStatusCode.ServiceUnavailable ||

--- a/Exceptions/AzureOpenAICommunicationException.cs
+++ b/Exceptions/AzureOpenAICommunicationException.cs
@@ -8,7 +8,7 @@ namespace AzureChatGptMiddleware.Exceptions
     /// Isso pode incluir erros de rede, timeouts, status codes de erro HTTP da API,
     /// ou problemas ao processar a resposta da API (ex: JSON malformado).
     /// </summary>
-    public class AzureOpenAIComunicationException : Exception
+    public class AzureOpenAICommunicationException : Exception
     {
         /// <summary>
         /// O código de status HTTP retornado pela API do Azure OpenAI, se aplicável.
@@ -21,32 +21,32 @@ namespace AzureChatGptMiddleware.Exceptions
         public string? ErrorResponseContent { get; }
 
         /// <summary>
-        /// Inicializa uma nova instância da classe <see cref="AzureOpenAIComunicationException"/>.
+        /// Inicializa uma nova instância da classe <see cref="AzureOpenAICommunicationException"/>.
         /// </summary>
         /// <param name="message">A mensagem que descreve o erro.</param>
-        public AzureOpenAIComunicationException(string message)
+        public AzureOpenAICommunicationException(string message)
             : base(message)
         {
         }
 
         /// <summary>
-        /// Inicializa uma nova instância da classe <see cref="AzureOpenAIComunicationException"/>.
+        /// Inicializa uma nova instância da classe <see cref="AzureOpenAICommunicationException"/>.
         /// </summary>
         /// <param name="message">A mensagem que descreve o erro.</param>
         /// <param name="innerException">A exceção que é a causa da exceção atual.</param>
-        public AzureOpenAIComunicationException(string message, Exception innerException)
+        public AzureOpenAICommunicationException(string message, Exception innerException)
             : base(message, innerException)
         {
         }
 
         /// <summary>
-        /// Inicializa uma nova instância da classe <see cref="AzureOpenAIComunicationException"/>.
+        /// Inicializa uma nova instância da classe <see cref="AzureOpenAICommunicationException"/>.
         /// </summary>
         /// <param name="message">A mensagem que descreve o erro.</param>
         /// <param name="statusCode">O código de status HTTP retornado pela API.</param>
         /// <param name="errorResponseContent">O conteúdo da resposta de erro da API.</param>
         /// <param name="innerException">A exceção que é a causa da exceção atual (opcional).</param>
-        public AzureOpenAIComunicationException(
+        public AzureOpenAICommunicationException(
             string message,
             HttpStatusCode statusCode,
             string? errorResponseContent = null,

--- a/Services/AzureOpenAIService.cs
+++ b/Services/AzureOpenAIService.cs
@@ -57,13 +57,13 @@ namespace AzureChatGptMiddleware.Services
             //        - Extrai o texto da primeira "choice" da IA.
             //        - Retorna o texto da IA ou uma mensagem de erro se o conteúdo estiver nulo.
             //    - Em caso de falha na chamada HTTP (ex: timeout, erro de rede):
-            //        - Lança AzureOpenAIComunicationException com detalhes do erro HTTP.
+            //        - Lança AzureOpenAICommunicationException com detalhes do erro HTTP.
             //    - Em caso de resposta da API com status de erro (não-2xx):
             //        - Lê o corpo do erro da API.
-            //        - Lança AzureOpenAIComunicationException com status code e corpo do erro.
+            //        - Lança AzureOpenAICommunicationException com status code e corpo do erro.
             //    - Em caso de JSON de resposta bem-sucedida, mas malformado ou com campos ausentes:
-            //        - Lança AzureOpenAIComunicationException com detalhes do erro de parsing.
-            // 6. Exceções inesperadas durante o processo também são capturadas e encapsuladas em AzureOpenAIComunicationException.
+            //        - Lança AzureOpenAICommunicationException com detalhes do erro de parsing.
+            // 6. Exceções inesperadas durante o processo também são capturadas e encapsuladas em AzureOpenAICommunicationException.
             try
             {
                 var systemPrompt = await _promptService.GetActivePromptContentAsync("email_response");
@@ -95,12 +95,12 @@ namespace AzureChatGptMiddleware.Services
                 catch (HttpRequestException httpEx) // Erros de rede, DNS, etc.
                 {
                     _logger.LogError(httpEx, "Erro de HttpRequest ao chamar Azure OpenAI API. URI: {RequestUri}", requestUri);
-                    throw new AzureOpenAIComunicationException($"Erro na comunicação HTTP com Azure OpenAI ao tentar acessar {requestUri}.", httpEx);
+                    throw new AzureOpenAICommunicationException($"Erro na comunicação HTTP com Azure OpenAI ao tentar acessar {requestUri}.", httpEx);
                 }
                 catch (TaskCanceledException timeoutEx) // Captura timeouts do HttpClient.
                 {
                     _logger.LogError(timeoutEx, "Timeout ao chamar Azure OpenAI API. URI: {RequestUri}", requestUri);
-                    throw new AzureOpenAIComunicationException($"Timeout na comunicação com Azure OpenAI ao tentar acessar {requestUri}.", timeoutEx);
+                    throw new AzureOpenAICommunicationException($"Timeout na comunicação com Azure OpenAI ao tentar acessar {requestUri}.", timeoutEx);
                 }
 
                 // Processa a resposta da API.
@@ -123,18 +123,18 @@ namespace AzureChatGptMiddleware.Services
                         {
                             // Resposta OK, mas sem o array 'choices' esperado.
                             _logger.LogWarning("Resposta da API Azure OpenAI bem-sucedida (Status: {StatusCode}), mas array 'choices' está vazio. Conteúdo: {ResponseContent}", response.StatusCode, responseContent);
-                            throw new AzureOpenAIComunicationException($"Resposta da API Azure OpenAI (Status: {response.StatusCode}) não continha 'choices' esperados.");
+                            throw new AzureOpenAICommunicationException($"Resposta da API Azure OpenAI (Status: {response.StatusCode}) não continha 'choices' esperados.");
                         }
                     }
                     catch (JsonException jsonEx) // Erro ao parsear o JSON.
                     {
                         _logger.LogError(jsonEx, "Erro ao parsear JSON da resposta da API Azure OpenAI (Status: {StatusCode}). Conteúdo: {ResponseContent}", response.StatusCode, responseContent);
-                        throw new AzureOpenAIComunicationException($"Erro ao interpretar a resposta JSON da API Azure OpenAI (Status: {response.StatusCode}).", jsonEx);
+                        throw new AzureOpenAICommunicationException($"Erro ao interpretar a resposta JSON da API Azure OpenAI (Status: {response.StatusCode}).", jsonEx);
                     }
                     catch (KeyNotFoundException keyEx) // Estrutura do JSON diferente do esperado.
                     {
                         _logger.LogError(keyEx, "Campo esperado não encontrado no JSON da resposta da API Azure OpenAI (Status: {StatusCode}). Conteúdo: {ResponseContent}", response.StatusCode, responseContent);
-                        throw new AzureOpenAIComunicationException($"Resposta da API Azure OpenAI (Status: {response.StatusCode}) com formato inesperado.", keyEx);
+                        throw new AzureOpenAICommunicationException($"Resposta da API Azure OpenAI (Status: {response.StatusCode}) com formato inesperado.", keyEx);
                     }
                 }
                 else
@@ -142,21 +142,21 @@ namespace AzureChatGptMiddleware.Services
                     // A API retornou um status code de erro (não-2xx).
                     var errorContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                     _logger.LogError("Erro na API Azure OpenAI. Status: {StatusCode}. Resposta: {ErrorContent}. URI: {RequestUri}", response.StatusCode, errorContent, requestUri);
-                    throw new AzureOpenAIComunicationException(
+                    throw new AzureOpenAICommunicationException(
                         $"Erro ao comunicar com Azure OpenAI. Status: {response.StatusCode}. URI: {requestUri}.",
                         response.StatusCode,
                         errorContent);
                 }
             }
-            catch (AzureOpenAIComunicationException) // Se já for a exceção customizada, apenas a relança.
+            catch (AzureOpenAICommunicationException) // Se já for a exceção customizada, apenas a relança.
             {
                 throw;
             }
             catch (Exception ex) // Captura qualquer outra exceção inesperada.
             {
                 _logger.LogError(ex, "Erro inesperado ao processar e-mail com Azure OpenAI.");
-                // Encapsula em AzureOpenAIComunicationException para padronizar o tratamento de erros.
-                throw new AzureOpenAIComunicationException("Erro inesperado no serviço Azure OpenAI.", ex);
+                // Encapsula em AzureOpenAICommunicationException para padronizar o tratamento de erros.
+                throw new AzureOpenAICommunicationException("Erro inesperado no serviço Azure OpenAI.", ex);
             }
         }
     }


### PR DESCRIPTION
## Summary
- rename `AzureOpenAIComunicationException` to `AzureOpenAICommunicationException`
- update EmailController to reference `AzureOpenAICommunicationException`
- update AzureOpenAIService to reference `AzureOpenAICommunicationException`

## Testing
- `dotnet build --no-restore` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68405ba335e4832985a0fe940eda60ef