### PR TITLE
Add TokenService unit test

### DIFF
--- a/AzureChatGptMiddleware.Tests/AzureChatGptMiddleware.Tests.csproj
+++ b/AzureChatGptMiddleware.Tests/AzureChatGptMiddleware.Tests.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AzureChatGptMiddleware.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/AzureChatGptMiddleware.Tests/TokenServiceTests.cs
+++ b/AzureChatGptMiddleware.Tests/TokenServiceTests.cs
@@ -1,0 +1,38 @@
+using System.IdentityModel.Tokens.Jwt;
+using Microsoft.Extensions.Configuration;
+using AzureChatGptMiddleware.Services;
+using Xunit;
+
+namespace AzureChatGptMiddleware.Tests;
+
+public class TokenServiceTests
+{
+    [Fact]
+    public void GenerateToken_ShouldReturnToken_WithConfiguredExpiration()
+    {
+        // Arrange
+        var expirationMinutes = 30;
+        var inMemorySettings = new Dictionary<string, string?>
+        {
+            {"JwtSettings:SecretKey", "mysecretkeymysecretkeymysecretkey"},
+            {"JwtSettings:Issuer", "TestIssuer"},
+            {"JwtSettings:Audience", "TestAudience"},
+            {"JwtSettings:ExpirationMinutes", expirationMinutes.ToString()}
+        };
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(inMemorySettings!)
+            .Build();
+        var tokenService = new TokenService(configuration);
+        var now = DateTime.UtcNow;
+
+        // Act
+        var token = tokenService.GenerateToken();
+
+        // Assert
+        Assert.False(string.IsNullOrWhiteSpace(token));
+        var handler = new JwtSecurityTokenHandler();
+        var jwt = handler.ReadJwtToken(token);
+        var diff = jwt.ValidTo - now;
+        Assert.InRange(diff.TotalMinutes, expirationMinutes - 0.5, expirationMinutes + 0.5);
+    }
+}

--- a/AzureChatGptMiddleware.csproj
+++ b/AzureChatGptMiddleware.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="AzureChatGptMiddleware.Tests/**/*" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.5">
       <PrivateAssets>all</PrivateAssets>

--- a/AzureChatGptMiddleware.sln
+++ b/AzureChatGptMiddleware.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.13.36105.23 d17.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureChatGptMiddleware", "AzureChatGptMiddleware.csproj", "{7CD08B58-29A5-422B-B9CF-66CED3BBE782}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureChatGptMiddleware.Tests", "AzureChatGptMiddleware.Tests\AzureChatGptMiddleware.Tests.csproj", "{97F65C08-916C-40FA-920F-F04831588C68}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{7CD08B58-29A5-422B-B9CF-66CED3BBE782}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7CD08B58-29A5-422B-B9CF-66CED3BBE782}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7CD08B58-29A5-422B-B9CF-66CED3BBE782}.Release|Any CPU.Build.0 = Release|Any CPU
+		{97F65C08-916C-40FA-920F-F04831588C68}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{97F65C08-916C-40FA-920F-F04831588C68}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{97F65C08-916C-40FA-920F-F04831588C68}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{97F65C08-916C-40FA-920F-F04831588C68}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add AzureChatGptMiddleware.Tests xUnit project
- exclude test sources from main project build
- unit test for TokenService.GenerateToken
- update solution with test project
- target frameworks set back to net9.0

## Testing
- `dotnet test AzureChatGptMiddleware.Tests/AzureChatGptMiddleware.Tests.csproj -v minimal` *(fails: Could not load type 'System.Buffers.Text.Base64Url')*

------
https://chatgpt.com/codex/tasks/task_e_68405ba666008329a071eec9811a842a